### PR TITLE
8.0.16.tar.gz - for real

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ This repository incorporates:
 `gh-ost` CI will use this repo as follows:
 
 - Clone it from within the Docker image
-- Deploy and boostrap MySQL master-replica environments
+- Deploy and bootstrap MySQL master-replica environments
 - Run `gh-ost` integration tests on each master-replica environment


### PR DESCRIPTION
Followup to #6 and #7 . I though it was a typo, but https://github.com/datacharmer/mysql-docker-minimal switched from `.tar.gz` to `.tar.xz`. I'm gonna try and standardize on `.tar.gz` first.